### PR TITLE
Changes for Ska3 and modern era

### DIFF
--- a/derive_via_ofls_eqns.py
+++ b/derive_via_ofls_eqns.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+import numpy as np
 from Quaternion import Quat
 
 # Confirm that Quat.transform gives the rotation matrix that
@@ -29,7 +29,7 @@ q_ra_dec_roll = Quat([20, 40, 60])
 #
 # This rotates the X-axis vector in ECI.
 #
-M = q_ra.transform .dot (q_dec.transform) .dot (q_roll.transform)
+M = q_ra.transform @ q_dec.transform @ q_roll.transform
 print('M\n', M)
 print('q_ra_dec_roll.transform\n', q_ra_dec_roll.transform)
 print((q_ra * q_dec * q_roll).transform)

--- a/index_template.html
+++ b/index_template.html
@@ -9,7 +9,7 @@
 
 <!--#include virtual="/mta/ASPECT/header.html"-->
 
-<h2> Chandra Aimpoint Trending {%if static%}(static version){%endif%}</h2>
+<h2> Chandra Aimpoint Trending</h2>
 
 <p>The observation aimpoint is defined as the position on the focal plane where an on-axis
 target is located, assuming that the SIM offset is zero and both Y Offset and Z Offset
@@ -29,60 +29,24 @@ off the detector.
 
 <p> The mean aimpoint drift adds to pointing uncertainty by introducing a discrepancy
 between the <em>predicted</em> median aimpoint (used in the planning process) and the
-actual median aimpoint around the time of observation.  Currently the predicted aimpoint for
-each detector is updated once per year, typically in late November prior to issuing an
-update to the
-<a href="http://cxc.harvard.edu/proposer/POG/html/">Proposers' Observatory Guide</a> for
-the subsequent Call for Proposals.  Once the yearly update is made aimpoint is assumed to
-be static (for planning purposes) until the next update.  As of 2015 this approximation is
-not adequate for pointing-sensitive observations.
+actual median aimpoint around the time of observation.  The predicted aimpoint for
+each detector fixed at a preset value since cycle 18 (2017) as stated in the
+<a href="http://cxc.harvard.edu/proposer/POG/html/">Proposers' Observatory Guide</a>.
 
-<h3> Webpage contents and usage </h3>
+The temperature-dependent ACA alignment shift is compensated by means of a
+dynamical pointing offset that is introduced into the planning process. See the
+<a href="https://docs.google.com/presentation/d/115aq7B2_TuieA3iu82cxKlEYsWUiqZ7df8jYP37qrq4/edit?usp=sharing">
+    FDB transition to dynamic aimpoints</a> for an overview and the
+    <a href="https://docs.google.com/document/d/11yi-gdWcJ6dwYfMOCX1DsLUlN6CneO9xFd4qsuiFGFU/edit?usp=sharing">
+    Aimpoint transition plan</a> for implementation details.
 
-<p> This webpage serves as a reference for both the long-term and current trend in the
-Chandra aimpoint.  It is updated daily and gives the effective bounding box of observed
-aimpoint positions in chip coordinates over the last 6 months.  At this time only ACIS-S
-and ACIS-I are included because there have been no pointing-sensitive observations on HRC
-to date.
+<h3>Legacy aimpoint monitor page and details</h3>
 
-<p>  Many users with pointing-sensitive observations will only need to reference the
-6-month aimpoint bounds and median and compare with the latest predicted aimpoint values.
-This will provide guidance for adjusting the target offset with assistance from your USINT
-contact.
-
-<h4> Going deeper </h4>
-
-{% if static %}
-<p>You are viewing the static version of the aimpoint trending page which includes static
-PNG figures.  If you would like to dig a little deeper and understand how this issue
-has evolved then return to the <a href="index.html">dynamic version</a>.
-{% else %}
-<p> To dig a little deeper and understand how this issue has evolved, <strong>the plots in this
-  page are live plots</strong>, powered by the
-  Python <a href="http://mpld3.github.io/">mpld3</a> package and ultimately by the
-  Javascript <a href="http://d3js.org/">D3</a> plotting engine.  The most insight can be
-  gained by using the linked brush feature which allows selecting points in one
-  panel and seeing the same points highlighted in the other panels.
-
-<p> To do this, left-click in the lower-right panel (CHIPY vs. Year) and drag the mouse up
-  and right to select a box that covers the full CHIPY range and about two years of data.
-  (You might need to click once in the plot first to get a + cursor).  Once you have a
-  gray selection box, carefully move your mouse into the box so that it turns into the
-  normal Move icon (four arrows pointing outward).  Now click and drag the box all the way
-  to the left and then slowly pan it rightward to mimic the progression of time.  Now you
-  will see a virtual movie of how the aimpoint has been dynamically changing.
-
-<p> <em> NOTES: </em>
-<ul>
-  <li> It may take a few seconds for the plots to initially load.  If they do not load in
-  time then there is a <a href="index_static.html">static version</a> of the page
-  available.</li>
-  <li> Chrome is far more responsive than Firefox.  Any feedback on how this page works on
-    Internet Explorer or other browsers would be appreciated. </li>
-</ul>
-
-{% endif %}
-
+For the historical version of the aimpoint trending page that was used as the
+basis for understanding the aimpoint issue and developing the dynamical offsets
+concept, see the <a href="https://cxc.harvard.edu/mta/ASPECT/aimpoint_mon/">
+Legacy aimpoint monitor</a> page. That page is no longer being updated, but
+includes key details of processing that are still relevant.
 
 <h3> Observed aimpoint differences trend </h3>
 
@@ -92,15 +56,11 @@ aimpoint chip coordinates (CHIPX/Y) and observer target offsets and the SIM-Z po
 The actual aimpoint is computed using <tt>dmcoords</tt> and keyword values from the CXC
 archive L2 X-ray event file.  The plot shows up to 6 months of data starting from when
 dynamic aimpoints were initially put into use (AUG2916 schedule).
-
-{% if static %}
+<p></p>
 <img src="observed_aimpoints_dx.png">
 <img src="observed_aimpoints_dy.png">
-{% else %}
-<!--#include virtual="observed_aimpoints_dx.html"-->
-<!--#include virtual="observed_aimpoints_dy.html"-->
-{% endif %}
 
+<p></p>
 The data values are stored in the observed aimpoints table
 (<a href="observed_aimpoints_table.html">HTML</a>
 or <a href="observed_aimpoints.dat">ASCII</a>).
@@ -112,203 +72,16 @@ However, from the perspective of planning observations this need not be
 considered because it is <em>already included</em> in the <a href="#aimpoint-trending">Aimpoint
   Trending</a> plots.  This is because those plots sample from 1 ksec intervals within
 every science observation (instead of per-observation means), thus picking up the extremes.
+<p></p>
 
-
-{% if static %}
 <img src="intra_obs_dy_dz.png">
-{% else %}
-<!--#include virtual="intra_obs_dy_dz.html"-->
-{% endif %}
 
-
-<h3 id="aimpoint-trending"> Aimpoint trending (current through obsid={{last_obsid}} on {{last_ctime}})</h3>
-
-The plots below show a representative sampling of aimpoint positions during Chandra
-science observations.  This includes points corresponding to the minimum, 10th percentile,
-median, 90th percentile, and maximum during one-month bins.  This sampling is complete
-with regard to outliers and does not distinguish between individual observations.  See the
-<a href="#details">Details</a> section for a full description of this process and links to
-the actual code.
-
-<p>In each plot there is a box which highlights the maximum range of aimpoint CHIPX and CHIPY
-within the last 6 months.  In addition there is a red star which shows the current
-aimpoint used for planning.
-
-<p>The numerical table values shown in this page are available in machine-readable JSON
-  format as <a href="info.json">info.json</a>.
-
-<h4 id="acis-s"> ACIS-S</h4>
-
-A key point to highlight for ACIS-S is that the planning aimpoint is at the extreme corner of
-the observed aimpoint extent.  This means that the aimpoints for some observations in the
-last 6 months have been offset by nearly 40 pixels in CHIPX and over 20 pixels in CHIPY.
-Another important point is that there is a strong correlation between CHIPX and CHIPY
-which is most apparent when viewing the data dynamically using the linked brush, but is
-also visible noting that the darkest red points are all from the last year of observations.
-
-<p>The coordinates of the 6-month bounding box (shaded box in the plot below) and the 2015.0
-planning aimpoint from the POG (red star) are:<br/><br/>
-
-<tt>
-<table class="white-double-lines">
-<tr><th></th> <th>Min</th> <th>Midpoint</th> <th>Max</th> <th>POG</th></tr>
-<tr><th>CHIPX</th>
-  <td>{{aciss.chipx.min|round(1)}}</td>
-  <td>{{aciss.chipx.mid|round(1)}}</td>
-  <td>{{aciss.chipx.max|round(1)}}</td>
-  <td>{{aciss.pogx|round(1)}}</td>
-</tr>
-<tr><th>CHIPY</th>
-  <td>{{aciss.chipy.min|round(1)}}</td>
-  <td>{{aciss.chipy.mid|round(1)}}</td>
-  <td>{{aciss.chipy.max|round(1)}}</td>
-  <td>{{aciss.pogy|round(1)}}</td>
-</tr>
-</table>
-</tt>
-
-<p>To account for the difference between the current POG value and the current
-aimpoint, <strong> ADD</strong> the following values to the existing observation target
-offsets DY and DZ:<br/><br/>
-<tt>
-<table class="white-double-lines">
-  <tr><th>DY</th> <td>{{"%+.1f"|format(aciss.dDY)}} arcsec</td><td>{{"%+.3f"|format(aciss.dDY_arcmin)}} arcmin</td></tr>
-  <tr><th>DZ</th> <td>{{"%+.1f"|format(aciss.dDZ)}} arcsec</td><td>{{"%+.3f"|format(aciss.dDZ_arcmin)}} arcmin</td></tr>
-</table>
-</tt>
-
-{% if static %}
-<img src="chip_x_y_aciss.png">
-{% else %}
-<!--#include virtual="chip_x_y_aciss.html"-->
-{% endif %}
-
-<h4 id="acis-i"> ACIS-I</h4>
-
-Although not as extreme as ACIS-S, the planning aimpoint for ACIS-I is offset by about
-20 pixels from the center of the 6-month box.
-
-<p>The coordinates of the 6-month bounding box (shaded box in the plot below) and the 2015.0
-planning aimpoint from the POG (red star) are:<br/><br/>
-
-<tt>
-<table class="white-double-lines">
-<tr><th></th> <th>Min</th> <th>Midpoint</th> <th>Max</th> <th>POG</th></tr>
-<tr><th>CHIPX</th>
-  <td>{{acisi.chipx.min|round(1)}}</td>
-  <td>{{acisi.chipx.mid|round(1)}}</td>
-  <td>{{acisi.chipx.max|round(1)}}</td>
-  <td>{{acisi.pogx|round(1)}}</td>
-</tr>
-<tr><th>CHIPY</th>
-  <td>{{acisi.chipy.min|round(1)}}</td>
-  <td>{{acisi.chipy.mid|round(1)}}</td>
-  <td>{{acisi.chipy.max|round(1)}}</td>
-  <td>{{acisi.pogy|round(1)}}</td>
-</tr>
-</table>
-</tt>
-
-<p>To account for the difference between the current POG value and the current
-aimpoint, <strong> ADD</strong> the following values to the existing observation target
-offsets DY and DZ:<br/><br/>
-<tt>
-<table class="white-double-lines">
-  <tr><th>DY</th> <td>{{"%+.1f"|format(acisi.dDY)}} arcsec</td><td>{{"%+.3f"|format(acisi.dDY_arcmin)}} arcmin</td></tr>
-  <tr><th>DZ</th> <td>{{"%+.1f"|format(acisi.dDZ)}} arcsec</td><td>{{"%+.3f"|format(acisi.dDZ_arcmin)}} arcmin</td></tr>
-</table>
-</tt>
-
-
-{% if static %}
-<img src="chip_x_y_acisi.png">
-{% else %}
-<!--#include virtual="chip_x_y_acisi.html"-->
-{% endif %}
-
-<h3 id="details"> Details</h3>
-
-<h4> Background </h4>
-
-<p>The relationship at the foundation of this work is the one-to-one correspondence
-between the aspect solution SIM offset values <tt>(DY, DZ)</tt> and the aimpoint offset.
-Those values are derived primarily by tracking positions of the fiducial lights which are
-located in the instrument focal plane and are imaged in the ACA by means of the Fiducial
-Transfer System optics.  The one-to-one correspondence relies on our understanding that
-the alignment of the HRMA optical axis relative to the science instruments is relatively
-stable (<a href="http://cxc.harvard.edu/cal/Hrma/OpticalAxisAndAimpoint.html">HRMA Optical
-Axis and Telescope Aimpoint</a>). This implies that any apparent drift in the fid
-positions is due to change in the ACA to HRMA alignment, and not distortion of the Optical
-Bench Assembly.  Prior to launch it had been surmised that the latter term would dominate.
-
-<p>The ACA is used by the on-board Pointing Control and Attitude Determination system to
-maintain pointing.  If the ACA alignment is shifting with respect to the HRMA - SIM
-system, then an aimpoint shift is observed.  Effectively the ACA points precisely at the
-target but the rest of the spacecraft hangs off the ACA and wanders somewhat in alignment.
-
+<h3>ACA housing temperature</h3>
 <p>The trend of ACA housing temperature is shown below, and one easily sees the qualitative similarity
-with the aimpoint trending data.<br/>
+    with the aimpoint trending data.<br/>
 
-
-{% if static %}
-<img src="aca_housing_temperature.png">
-{% else %}
-<!--#include virtual="aca_housing_temperature.html"-->
-{% endif %}
-
-<h4> Processing </h4>
-
-<p>Aspect level-1 processing of each science observations produces an aspect solution file
-that is sampled each 0.25625 seconds and contains the <tt>(DY, DZ)</tt> values
-corresponding to the ACA alignment shift.  The minimum time scale for significant shifts
-is about 10 ksec, so our ingest code takes a sample every 1.0 ksec, with a minimum of 2
-samples for each observation.  This was done for all observations since 2000:001 and the
-data stored in a single HDF5 file.  A daily cron job adds new aspect solution data as they
-become available.
-
-<p> The raw data are available in FITS format
-  in <a href="aimpoint_asol_values.fits">aimpoint_asol_values.fits</a>.
-
-<p>Converting from <tt>(DY, DZ)</tt> to <tt>(CHIPX, CHIPY)</tt> is a simple linear
-transformation if only ~arcsec accuracy is required.  In this case that is sufficient.
-Deriving and validating this tranformation is not entirely trivial, and is documented
-in this IPython notebook
-on <a href="https://github.com/sot/aimpoint_mon/blob/master/absolute_pointing_uncertainty.ipynb">
-Absolute Pointing Uncertainty</a>.  (This notebook is currently rough and poorly
-  documented, but I plan to address this.)  The resultant transformations from
-aspect solution DY and DZ to CHIPX and CHIPY are shown
-below.  Note that in the IPython notebook the DY and DZ values refer to the dmcoords inputs
-which have the sign <em>reversed</em> from the ASOL values.
-<pre>
-<table class="white-double-lines">
-  <tr><th>ACIS-S</th> <th>ACIS-I</th></tr>
-  <td>
-    CHIPX = 252.25 - 41.69 * DY<br/>
-    CHIPY = 519.95 - 41.67 * DZ
-  </td>
-  <td>
-    CHIPX = 971.91 - 41.74 * DZ<br/>
-    CHIPY = 963.07 + 41.74 * DY
-  </td>
-</tr>
-</table>
-</pre>
-
-<p>The step of generating presentation plots to visualize and understand the data takes
-  some care.  In order to see the expanding extent with TIME while also getting a sense of
-  the CHIPX - CHIPY correlation, we need to visualize all three axes.  A 3-d plot might
-  work, but static 2-d representations of 3-d data can be unsatisfying.  Instead the
-  strategy is to use <a href="https://en.wikipedia.org/wiki/Brushing_and_linking">linking
-  and brushing</a> and a Javascript-powered live plot in the web page.  In order to do
-  this and have manageable page load times, we need to sample the data while capturing
-  behavior of the extrema which matter here.
-
-<p>The approach taken is to bin the data in one month intervals.  Within each bin find the
-  row that contains the minimum, 10th percentile, 50th percentile (median), 90th
-  percentile, and maximum of CHIPX.  For each of those rows sample CHIPX and CHIPY.
-  Now repeat that process for the rows containing percentile values of CHIPY.  This
-  gives 10 CHIPX, CHIPY pairs for each month.  This fills out the sampling reasonably well.
-
+    <p></p>
+    <img src="aca_housing_temperature.png">
 
 <h4> Analysis code</h4> The scripts used in this analysis are in available on
 GitHub in

--- a/make_web_page.py
+++ b/make_web_page.py
@@ -36,7 +36,7 @@ logger.info('Loading info file {}'.format(info_file))
 context = json.load(open(info_file, 'r'))
 
 # Get the last record of asol aimpoint values
-h5 = tables.openFile(asol_file)
+h5 = tables.open_file(asol_file)
 last = h5.root.data[-1]
 h5.close()
 

--- a/make_web_page.py
+++ b/make_web_page.py
@@ -17,6 +17,7 @@ def get_opt():
                         help="Root directory for asol and index files")
     return parser.parse_args()
 
+
 # Options
 opt = get_opt()
 
@@ -27,8 +28,7 @@ logger = pyyaks.logger.get_logger(name='make_web_page', level=loglevel,
 # Files
 asol_file = os.path.join(opt.data_root, 'aimpoint_asol_values.h5')
 index_template_file = os.path.join(opt.data_root, 'index_template.html')
-index_files = {False: os.path.join(opt.data_root, 'index.html'),
-               True: os.path.join(opt.data_root, 'index_static.html')}
+index_file = os.path.join(opt.data_root, 'index.html')
 info_file = os.path.join(opt.data_root, 'info.json')
 
 # Jinja template context
@@ -42,10 +42,8 @@ h5.close()
 
 template = Template(open(index_template_file).read())
 
-for static in (True, False):
-    context['static'] = static
-    html = template.render(**context)
-    index_file = index_files[static]
-    logger.info('Writing index file {}'.format(index_file))
-    with open(index_file, 'w') as fh:
-        fh.write(html)
+context['static'] = True
+html = template.render(**context)
+logger.info('Writing index file {}'.format(index_file))
+with open(index_file, 'w') as fh:
+    fh.write(html)

--- a/plot_aimpoint.py
+++ b/plot_aimpoint.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-
-
 import json
 import re
 import os
@@ -21,8 +19,6 @@ matplotlib.use('Agg')
 
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
-
-import mpld3
 
 # Set up logging
 loglevel = pyyaks.logger.INFO
@@ -78,7 +74,6 @@ def get_asol(info=None):
     logger.info('Reading asol file {}'.format(h5_file))
     with tables.open_file(h5_file) as h5:
         asol = Table(h5.root.data[:])
-
     bad = (asol['dy'] == 0.0) & (asol['dz'] == 0.0)
     asol = asol[~bad]
 
@@ -265,13 +260,10 @@ class AsolBinnedStats(object):
         axes[0].legend(loc='upper left', fontsize='small', title='')
         axes[1].set_xlabel('Year')
 
-        mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt='.1f'))
-
         outroot = os.path.join(opt.data_root, 'intra_obs_dy_dz')
-        logger.info('Writing plot files {}.png,html'.format(outroot))
-        mpld3.save_html(fig, outroot + '.html')
+        logger.info('Writing plot files {}.png'.format(outroot))
         fig.patch.set_visible(False)
-        plt.savefig(outroot + '.png', frameon=False)
+        plt.savefig(outroot + '.png', facecolor="none")
 
     def get_chip_x_y_info(self):
         """
@@ -396,15 +388,10 @@ class AsolBinnedStats(object):
         ax3.yaxis.tick_right()
         ax3.grid()
 
-        plt.show()
-        mpld3.plugins.connect(fig, mpld3.plugins.LinkedBrush(points))
-        mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt='.1f'))
-
         outroot = os.path.join(opt.data_root, 'chip_x_y_{}'.format(self.det_title))
-        logger.info('Writing plot files {}.png,html'.format(outroot))
-        mpld3.save_html(fig, outroot + '.html')
+        logger.info('Writing plot files {}.png'.format(outroot))
         fig.patch.set_visible(False)
-        plt.savefig(outroot + '.png', frameon=False)
+        plt.savefig(outroot + '.png', facecolor="none")
 
 
 def plot_housing_temperature():
@@ -419,11 +406,9 @@ def plot_housing_temperature():
     plt.title('Aspect Camera housing temperature trend')
 
     outroot = os.path.join(opt.data_root, 'aca_housing_temperature')
-    logger.info('Writing plot files {}.png,html'.format(outroot))
-    mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fmt='.1f'))
-    mpld3.save_html(fig, outroot + '.html')
+    logger.info('Writing plot files {}.png'.format(outroot))
     fig.patch.set_visible(False)
-    plt.savefig(outroot + '.png', frameon=False)
+    plt.savefig(outroot + '.png', facecolor="none")
 
 
 def make_pure_python(obj):

--- a/plot_aimpoint.py
+++ b/plot_aimpoint.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-from __future__ import division
+
 
 import json
 import re
 import os
 import argparse
-from itertools import izip
+
 
 import numpy as np
 from astropy.table import Table, Column
@@ -76,9 +76,8 @@ def get_asol(info=None):
 
     h5_file = os.path.join(opt.data_root, 'aimpoint_asol_values.h5')
     logger.info('Reading asol file {}'.format(h5_file))
-    h5 = tables.openFile(h5_file)
-    asol = Table(h5.root.data[:])
-    h5.close()
+    with tables.open_file(h5_file) as h5:
+        asol = Table(h5.root.data[:])
 
     bad = (asol['dy'] == 0.0) & (asol['dz'] == 0.0)
     asol = asol[~bad]
@@ -189,7 +188,7 @@ class AsolBinnedStats(object):
             _attr = '_' + attr
             if not hasattr(self, _attr):
                 rows = []
-                for group, isort in izip(self.grouped.groups, self.argsort[col]):
+                for group, isort in zip(self.grouped.groups, self.argsort[col]):
                     ii = (int(perc) * (len(group) - 1)) // 100
                     rows.append(group[isort[ii]])
                 val = Table(rows=rows, names=self.grouped.colnames)
@@ -236,7 +235,7 @@ class AsolBinnedStats(object):
         for col in ('dy', 'dz'):
             for perc in (50, 90, -5):
                 rows = []
-                for group, i_sort in izip(t_bin.groups, i_sorts[col]):
+                for group, i_sort in zip(t_bin.groups, i_sorts[col]):
                     if perc < 0:
                         for row in group[i_sort[perc:]]:
                             rows.append(row)
@@ -247,8 +246,8 @@ class AsolBinnedStats(object):
 
         plt.close(1)
         fig, axes = plt.subplots(nrows=2, ncols=1, sharex=True, num=1)
-        for col, ax in izip(('dy', 'dz'), axes):
-            for perc, color in izip((50, 90, -5), ('b', 'm', 'r')):
+        for col, ax in zip(('dy', 'dz'), axes):
+            for perc, color in zip((50, 90, -5), ('b', 'm', 'r')):
                 t = outs[str(perc) + col]
                 if perc < 0:
                     ax.plot(t['year'], t[col], '.', color=color, markersize=5,

--- a/update_aimpoint_data.py
+++ b/update_aimpoint_data.py
@@ -70,7 +70,7 @@ def get_asol(obsid, asol_files, dt):
 
 def add_asol_to_h5(filename, asol):
     asol = asol.as_array()
-    with tables.openFile(filename, mode='a',
+    with tables.open_file(filename, mode='a',
                           filters=tables.Filters(complevel=5, complib='zlib')) as h5:
         try:
             logger.info('Appending {} records to {}'.format(len(asol), filename))

--- a/update_aimpoint_data.py
+++ b/update_aimpoint_data.py
@@ -2,9 +2,11 @@
 
 import os
 import re
-import shelve
 import argparse
 import tables
+from pathlib import Path
+import pickle
+
 import numpy as np
 
 from Chandra.Time import DateTime
@@ -47,7 +49,7 @@ def get_asol(obsid, asol_files, dt):
     else:
         cols = ('time', 'dy', 'dz', 'dtheta')
     asols = [asol[cols] for asol in asols]
-    asol = vstack(asols)
+    asol = vstack(asols, metadata_conflicts='silent')
 
     # And rename any raw columns to use the old names
     if np.any(has_raws):
@@ -95,8 +97,6 @@ logger.info('Processsing from {} to {}'.format(start.date, stop.date))
 # Define file names
 h5_file = os.path.join(opt.data_root, 'aimpoint_asol_values.h5')
 
-# When we go to PY3, just remove '.shelve' to make this work.
-obsid_file = os.path.join(opt.data_root, 'aimpoint_obsid_index.shelve')
 
 # Get obsids in date range
 mica_obspar_db = os.path.join(MICA_ARCHIVE, 'obspar', 'archfiles.db3')
@@ -112,7 +112,13 @@ obs.sort('tstart')
 obs['datestart'] = Time(obs['tstart'], format='cxcsec').yday
 obs.pprint(max_lines=-1)
 
-obsid_index = shelve.open(obsid_file)
+# Dict of obsid => list of ASPSOL files. This keeps track of obsids that have
+# been processed.
+obsid_file = Path(opt.data_root) / 'aimpoint_obsid_index.pkl'
+if obsid_file.exists():
+    obsid_index = pickle.load(open(obsid_file, 'rb'))
+else:
+    obsid_index = {}
 
 # Go through obsids and either process or skip
 for obsid in obs['obsid']:
@@ -130,7 +136,7 @@ for obsid in obs['obsid']:
     add_asol_to_h5(h5_file, asol)
     obsid_index[str(obsid)] = asol_files
 
-obsid_index.close()
+pickle.dump(obsid_index, open(obsid_file, 'wb'))
 
 logger.info('File {} updated'.format(h5_file))
 logger.info('File {} updated'.format(obsid_file))

--- a/update_characteristics.py
+++ b/update_characteristics.py
@@ -193,7 +193,7 @@ def write_index_file(info_table):
         updated_file       baseline_file           date       dy_acis_i dz_acis_i dy_acis_s dz_acis_s
     ------------------- ------------------- ----------------- --------- --------- --------- ---------
     CHARACTERIS_12OCT15 CHARACTERIS_12MAR15 2015:285:01:21:25     -5.00     10.00     15.00    -20.00
-    """
+    """  # noqa
     index_file = os.path.join(opt.data_root, 'characteristics', 'index')
     if os.path.exists(index_file):
         index = Table.read(index_file, format='ascii.fixed_width_two_line', guess=False)
@@ -324,6 +324,7 @@ def main():
     print('SEND FOLLOWING EMAIL\n')
     out = get_email_text(info['baseline_file'], info['updated_file'])
     print(out)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR updates the aimpoint monitor code to run in Ska3.

- Basic Python 3 updates
- Matplotlib fixes
- Added a label describing the star points on the main aimpoint trend plot.
- Remove the mpld3 plots: these were useful originally but no longer bring anything useful. This was driven in part by the mpld3 plots just not working, so debugging this would not be worth the effort.
- Update the index template to reflect our modern use of this web page. 
  - The CHIPX vs CHIPY plots for ACIS I/S were removed since the content was misleading now. Those plots do not account for dynamic offsets and are now no better than the fid drift plots.
  - The text now reflects the current situation with dynamical offsets in place.
- Changed to use a pickle file instead of `shelve` for the aimpoint obsid index file. This wasn't helping much. Reading the Python 2 shelf in Python 3 wasn't working. This does require a one-time migration, which I have done locally in my repo on kady.
- Removed `evts_meta.shelf`. This wasn't actually getting used in practice and was apparently orphaned.

## Testing (on kady in Ska3 flight)

I copied the existing contents from a one-week old snapshot of /proj/sot/ska/data/aimpoint_mon into a local `data` directory. Then I locally ran each of the four python scripts that get run in task_schedule on that `data` dir.

The web page looks as expected (see `~aldcroft/git/aimpoint_mon/data/index.html`) and the key plot is below. It looks pretty much like the current flight plot.

![image](https://user-images.githubusercontent.com/348089/103481806-157a1200-4dab-11eb-9489-ffa226e2a48d.png)

## Plan

After this PR is merged then I'll do a follow-up to turn this into an installable Ska3 package.
