### PR TITLE
Fix some residual issues in the Py3 implementation

### DIFF
--- a/aimpoint_mon/plot_aimpoint.py
+++ b/aimpoint_mon/plot_aimpoint.py
@@ -92,7 +92,7 @@ def get_asol(info=None):
     normal_suns.interval_pad = 10000, 86400 * 3
     safe_suns.interval_pad = 10000, 86400 * 3
     exclude_intervals = (normal_suns | safe_suns).intervals(asol['time'][0], asol['time'][-1])
-    ok = np.ones(len(asol), dtype=np.bool)
+    ok = np.ones(len(asol), dtype=bool)
     for date0, date1 in exclude_intervals:
         logger.info('Excluding asol values from {} to {} (normal/safe sun)'.format(date0, date1))
         i0, i1 = np.searchsorted(asol['time'], Time([date0, date1], format='yday').cxcsec)

--- a/aimpoint_mon/plot_aimpoint.py
+++ b/aimpoint_mon/plot_aimpoint.py
@@ -165,12 +165,6 @@ class AsolBinnedStats(object):
     def ccd(self):
         return 'I3' if self.det.lower().endswith('i') else 'S3'
 
-    @property
-    def argsort(self):
-        if not hasattr(self, '_argsort'):
-            self._argsort = self.grouped.groups.aggregate(np.argsort)
-        return self._argsort
-
     def __getattr__(self, attr):
         """
         If the requested ``attr`` is of the form "p<percentile>_<colname>" for
@@ -183,7 +177,8 @@ class AsolBinnedStats(object):
             _attr = '_' + attr
             if not hasattr(self, _attr):
                 rows = []
-                for group, isort in zip(self.grouped.groups, self.argsort[col]):
+                for group in self.grouped.groups:
+                    isort = np.argsort(group[col])
                     ii = (int(perc) * (len(group) - 1)) // 100
                     rows.append(group[isort[ii]])
                 val = Table(rows=rows, names=self.grouped.colnames)
@@ -221,16 +216,14 @@ class AsolBinnedStats(object):
         t['ybin'] = np.trunc((t['year'] - t['year'][-1] - 0.0001) * 4.0)
 
         # Now group the dx and dy vals in 3-month intervals and find the 50th
-        # and 90th percentile within each time bin.  This again using aggregation,
-        # but this time in a trickier way by returning a Column object as the
-        # aggregation object instead of a single value.
+        # and 90th percentile within each time bin.
         t_bin = t.group_by('ybin')
-        i_sorts = t_bin.groups.aggregate(np.argsort)
         outs = {}
         for col in ('dy', 'dz'):
             for perc in (50, 90, -5):
                 rows = []
-                for group, i_sort in zip(t_bin.groups, i_sorts[col]):
+                for group in t_bin.groups:
+                    i_sort = np.argsort(group[col])
                     if perc < 0:
                         for row in group[i_sort[perc:]]:
                             rows.append(row)

--- a/aimpoint_mon/update_observed_aimpoints.py
+++ b/aimpoint_mon/update_observed_aimpoints.py
@@ -18,7 +18,7 @@ from mica.starcheck import get_mp_dir
 import Ska.Shell
 import Ska.arc5gl
 from kadi import events
-from Chandra.Time import DateTime
+from cxotime import CxoTime
 import pyyaks.logger
 
 import matplotlib
@@ -255,8 +255,8 @@ def update_observed_aimpoints():
     the delta offset from the planned value.
     """
     # Default is between NOW and NOW - 14 days
-    start = DateTime(opt.start) - (14 if opt.start is None else 0)
-    stop = DateTime(opt.stop)
+    start = CxoTime(opt.start) - (14 if opt.start is None else 0)
+    stop = CxoTime(opt.stop)
 
     # Get science obsids
     obsids = [evt.obsid for evt in events.obsids.filter(start, stop)
@@ -317,7 +317,7 @@ def plot_observed_aimpoints(obs_aimpoints):
     Make png plot of data in the ``obs_aimpoints`` table.
     """
 
-    dates = DateTime(obs_aimpoints['mean_date'])
+    dates = CxoTime(obs_aimpoints['mean_date'])
     years = dates.frac_year
     times = dates.secs
     ok = years > np.max(years) - float(opt.lookback) / 365.25
@@ -352,11 +352,11 @@ def plot_observed_aimpoints(obs_aimpoints):
                 plot_cxctime(times[nok], obs_aimpoints[axis][nok], marker='*',
                              markerfacecolor=c, **kwargs)
             if np.any(lolims[axis]):
-                plt.errorbar(DateTime(times[lolims[axis]]).plotdate,
+                plt.errorbar(CxoTime(times[lolims[axis]]).plot_date,
                              obs_aimpoints[axis][lolims[axis]], marker='.',
                              markerfacecolor=c, yerr=1.5, lolims=True, **kwargs)
             if np.any(uplims[axis]):
-                plt.errorbar(DateTime(times[uplims[axis]]).plotdate,
+                plt.errorbar(CxoTime(times[uplims[axis]]).plot_date,
                              obs_aimpoints[axis][uplims[axis]], marker='.',
                              markerfacecolor=c, yerr=1.5, uplims=True, **kwargs)
         plt.grid()

--- a/aimpoint_mon/update_observed_aimpoints.py
+++ b/aimpoint_mon/update_observed_aimpoints.py
@@ -292,7 +292,7 @@ def update_observed_aimpoints():
                     'chipx={chipx:.1f} chipy={chipy:.1f} dx={dx:.1f} dy={dy:.1f} dr={dr:.1f}'
                     .format(**vals))
         if abs(vals['dx']) > 10 or abs(vals['dy']) > 10:
-            logger.warn('WARNING: large dx or dy')
+            logger.warning('WARNING: large dx or dy')
 
         rows.append(vals)
 

--- a/aimpoint_mon/update_observed_aimpoints.py
+++ b/aimpoint_mon/update_observed_aimpoints.py
@@ -13,6 +13,7 @@ import argparse
 import warnings
 
 import numpy as np
+import astropy.units as u
 from astropy.table import Table, vstack
 from mica.starcheck import get_mp_dir
 import Ska.Shell
@@ -255,7 +256,7 @@ def update_observed_aimpoints():
     the delta offset from the planned value.
     """
     # Default is between NOW and NOW - 14 days
-    start = CxoTime(opt.start) - (14 if opt.start is None else 0)
+    start = CxoTime(opt.start) - (14 if opt.start is None else 0) * u.day
     stop = CxoTime(opt.stop)
 
     # Get science obsids


### PR DESCRIPTION
## Description

The original testing for the Py3 version of the aimpoint_mon lacked coverage for the case where there are offset outliers. Trying to run the same code again today generated a bunch of warnings from matplotlib and a plot that was not useful. This PR fixes that.

Along the way I saw a `VisibleDeprecationWarning` from numpy. This may have been missed the first time through because it was still working, but I fixed it now.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
From within the aimpoint_mon repo in ska3-flight 2022.13 on kady, this updates data from a week-old snapshot of the prior data:
```
rm -rf data/*
rsync -av /proj/sot/.snapshot/weekly.2023-01-22_0015/ska/data/aimpoint_mon/ data/
cd data
rm -rf *.png *.html characteristics/ logs *.json *.cfg

python -m aimpoint_mon.update_aimpoint_data --data-root=data
python -m aimpoint_mon.update_observed_aimpoints --data-root=data
python -m aimpoint_mon.plot_aimpoint --data-root=data
python -m aimpoint_mon.make_web_page --data-root=data
```
Output is at: https://cxc.cfa.harvard.edu/mta/ASPECT/tests/aimpoint_mon/2023-01-28/
